### PR TITLE
Store the original import filename in the generated schema

### DIFF
--- a/schematic/include/schematic/schema.h
+++ b/schematic/include/schematic/schema.h
@@ -18,6 +18,7 @@ namespace potato::schematic
     struct Annotation;
     struct EnumItem;
     struct Field;
+    struct Import;
     struct Location;
     struct Module;
     struct Schema;
@@ -121,11 +122,17 @@ namespace potato::schematic
         Location location;
     };
 
+    struct Import
+    {
+        const char* import = nullptr;
+        ModuleIndex module = InvalidIndex;
+    };
+
     struct Module
     {
         const char* filename = nullptr;
         TypeIndex index = InvalidIndex;
-        ReadOnlySpan<ModuleIndex> imports;
+        ReadOnlySpan<Import> imports;
     };
 
     struct Schema

--- a/schematic/schematic.proto
+++ b/schematic/schematic.proto
@@ -19,10 +19,16 @@ message Schema
     uint32 root = 10;
 }
 
+message Import
+{
+    string import = 1;
+    uint32 module = 2;
+}
+
 message Module
 {
     string filename = 1;
-    repeated uint32 imports = 2;
+    repeated Import imports = 2;
 }
 
 message Field

--- a/schematic/source/schema_gen.cpp
+++ b/schematic/source/schema_gen.cpp
@@ -53,13 +53,16 @@ ModuleIndex SchemaGenerator::CreateModule(IRModule* irModule)
     modules_.EmplaceBack(arena_);
     modules_[irModule->index].filename = arena_.NewString(irModule->filename);
 
-    Array<ModuleIndex> imports = arena_.NewArray<ModuleIndex>(irModule->imports.Size());
+    Array<Import> imports = arena_.NewArray<Import>(irModule->imports.Size());
     for (IRImport* const irImport : irModule->imports)
     {
         if (irImport->resolved->index == InvalidIndex)
             CreateModule(irImport->resolved);
 
-        imports.PushBack(arena_, irImport->resolved->index);
+        Import& import = imports.EmplaceBack(arena_);
+        if (irImport->ast != nullptr)
+            import.import = arena_.NewString(irImport->ast->target->value);
+        import.module = irImport->resolved->index;
     }
     modules_[irModule->index].imports = imports;
 

--- a/test/schemas/complete-accept.json
+++ b/test/schemas/complete-accept.json
@@ -3,8 +3,14 @@
   {
    "filename": "schemas/complete.sat",
    "imports": [
-    1,
-    2
+    {
+     "import": "",
+     "module": 1
+    },
+    {
+     "import": "sub/imported.sat",
+     "module": 2
+    }
    ]
   },
   {
@@ -14,7 +20,10 @@
   {
    "filename": "schemas/sub/imported.sat",
    "imports": [
-    1
+    {
+     "import": "",
+     "module": 1
+    }
    ]
   }
  ],

--- a/test/schemas/message-accept.json
+++ b/test/schemas/message-accept.json
@@ -3,7 +3,10 @@
   {
    "filename": "schemas/message.sat",
    "imports": [
-    1
+    {
+     "import": "",
+     "module": 1
+    }
    ]
   },
   {


### PR DESCRIPTION
Useful in codegen separate from the on-disk path