### PR TITLE
Use lowercase schematicConfig and schematicTargets for Linux compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,16 +48,16 @@ if(SCHEMATIC_INSTALL)
     )
 
     export(EXPORT SchematicTargets
-        FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/SchematicTargets.cmake"
+        FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/schematicTargets.cmake"
         NAMESPACE schematic::
     )
 
     include(CMakePackageConfigHelpers)
     configure_package_config_file(SchematicConfig.cmake.in
-        ${CMAKE_CURRENT_BINARY_DIR}/SchematicConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/schematicConfig.cmake
         INSTALL_DESTINATION lib/cmake/schematic
     )
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/SchematicConfig.cmake
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/schematicConfig.cmake
         DESTINATION lib/cmake/schematic
     )
 endif()

--- a/SchematicConfig.cmake.in
+++ b/SchematicConfig.cmake.in
@@ -3,7 +3,7 @@
 include(CMakeFindDependencyMacro)
 find_dependency(fmt CONFIG REQUIRED)
 
-include("${CMAKE_CURRENT_LIST_DIR}/SchematicTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/schematicTargets.cmake")
 
 set_and_check(schematic_INCLUDE_DIR ${PACKAGE_PREFIX_DIR}/include)
 set(schematic_LIBRARIES schematic::schematic)


### PR DESCRIPTION
Using uppercase names doesn't match convention of lowercase package name, which doesn't matter on Windows but does on case-sensitive filesystems.