### PR TITLE
Fix field indices with imported field types

### DIFF
--- a/schematic/source/ir_gen.cpp
+++ b/schematic/source/ir_gen.cpp
@@ -1064,10 +1064,12 @@ void IRGenerator::AssignIndices(IRType* type, IRSchema* schema)
 
     if (IRTypeAttribute* const attributeType = CastTo<IRTypeAttribute>(type); attributeType != nullptr)
     {
+        // assign indices sequentially before recursing, so indices are contiguous
         for (IRField* const field : attributeType->fields)
-        {
             field->index = schema->maxFieldIndex++;
 
+        for (IRField* const field : attributeType->fields)
+        {
             AssignIndices(field->type, schema);
             if (field->value != nullptr)
                 AssignIndices(field->value, schema);
@@ -1089,10 +1091,12 @@ void IRGenerator::AssignIndices(IRType* type, IRSchema* schema)
     }
     else if (IRTypeMessage* const messageType = CastTo<IRTypeMessage>(type); messageType != nullptr)
     {
+        // assign indices sequentially before recursing, so indices are contiguous
         for (IRField* const field : messageType->fields)
-        {
             field->index = schema->maxFieldIndex++;
 
+        for (IRField* const field : messageType->fields)
+        {
             AssignIndices(field->type, schema);
             if (field->value != nullptr)
                 AssignIndices(field->value, schema);
@@ -1105,10 +1109,12 @@ void IRGenerator::AssignIndices(IRType* type, IRSchema* schema)
         if (structType->base != nullptr)
             AssignIndices(structType->base, schema);
 
+        // assign indices sequentially before recursing, so indices are contiguous
         for (IRField* const field : structType->fields)
-        {
             field->index = schema->maxFieldIndex++;
 
+        for (IRField* const field : structType->fields)
+        {
             AssignIndices(field->type, schema);
             if (field->value != nullptr)
                 AssignIndices(field->value, schema);
@@ -1121,10 +1127,12 @@ void IRGenerator::AssignIndices(IRType* type, IRSchema* schema)
         if (structVersionedType->base != nullptr)
             AssignIndices(structVersionedType->base, schema);
 
+        // assign indices sequentially before recursing, so indices are contiguous
         for (IRField* const field : structVersionedType->fields)
-        {
             field->index = schema->maxFieldIndex++;
 
+        for (IRField* const field : structVersionedType->fields)
+        {
             AssignIndices(field->type, schema);
             if (field->value != nullptr)
                 AssignIndices(field->value, schema);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ schematic_embed_schemas(TARGET schematic_test SCHEMAS
     "schemas/array.sat"
     "schemas/builtin.sat"
     "schemas/enum.sat"
+    "schemas/fields.sat"
     "schemas/initializers.sat"
     "schemas/message.sat"
     "schemas/modifiers.sat"
@@ -37,6 +38,7 @@ schematic_embed_schemas(TARGET schematic_test SCHEMAS
     "schemas/versions.sat"
 
     "schemas/include/imported.sat"
+    "schemas/include/inner.sat"
     "schemas/include/preamble_impl.sat"
 
     "schemas/fail/circular_import.sat"

--- a/test/evaluator.cpp
+++ b/test/evaluator.cpp
@@ -282,6 +282,8 @@ namespace schematic::test
 
         if (Match("@type"))
             return Evaluate(field->type);
+        if (Match("@index"))
+            return Evaluate(field->index.index);
         if (Match("@default"))
             return Evaluate(field->value);
         if (Match("@proto"))

--- a/test/schemas/fields.sat
+++ b/test/schemas/fields.sat
@@ -1,0 +1,15 @@
+import "include/inner.sat";
+
+struct outer {
+    int32 first;
+    inner second;
+    int32 third;
+}
+
+// CHECK: inner.@fields == 1
+// CHECK: inner.value.@index == 0
+
+// CHECK: outer.@fields == 3
+// CHECK: outer.first.@index == 1
+// CHECK: outer.second.@index == 2
+// CHECK: outer.third.@index == 3

--- a/test/schemas/fields.sat
+++ b/test/schemas/fields.sat
@@ -7,9 +7,9 @@ struct outer {
 }
 
 // CHECK: inner.@fields == 1
-// CHECK: inner.value.@index == 0
+// CHECK: inner.value.@index == 3
 
 // CHECK: outer.@fields == 3
-// CHECK: outer.first.@index == 1
-// CHECK: outer.second.@index == 2
-// CHECK: outer.third.@index == 3
+// CHECK: outer.first.@index == 0
+// CHECK: outer.second.@index == 1
+// CHECK: outer.third.@index == 2

--- a/test/schemas/include/inner.sat
+++ b/test/schemas/include/inner.sat
@@ -1,0 +1,3 @@
+struct inner {
+    int32 value;
+}


### PR DESCRIPTION
If a struct had a field whose type came from an imported file, the indices would not be sequential. Fix that and add a test to catch it.